### PR TITLE
fix: Support filenames with commas

### DIFF
--- a/frappe_s3_attachment/controller.py
+++ b/frappe_s3_attachment/controller.py
@@ -185,8 +185,8 @@ class S3Operations(object):
                 'Key': key,
 
         }
-        if file_name:
-            params['ResponseContentDisposition'] = 'filename={}'.format(file_name)
+        # if file_name:
+        #     params['ResponseContentDisposition'] = 'filename={}'.format(file_name)
 
         url = self.S3_CLIENT.generate_presigned_url(
             'get_object',
@@ -232,9 +232,9 @@ def file_upload_to_s3(doc, method):
         frappe.db.sql("""UPDATE `tabFile` SET file_url=%s, folder=%s,
             old_parent=%s, content_hash=%s WHERE name=%s""", (
             file_url, 'Home/Attachments', 'Home/Attachments', key, doc.name))
-        
+
         doc.file_url = file_url
-        
+
         if parent_doctype and frappe.get_meta(parent_doctype).get('image_field'):
             frappe.db.set_value(parent_doctype, parent_name, frappe.get_meta(parent_doctype).get('image_field'), file_url)
 

--- a/frappe_s3_attachment/controller.py
+++ b/frappe_s3_attachment/controller.py
@@ -185,8 +185,6 @@ class S3Operations(object):
                 'Key': key,
 
         }
-        # if file_name:
-        #     params['ResponseContentDisposition'] = 'filename={}'.format(file_name)
 
         url = self.S3_CLIENT.generate_presigned_url(
             'get_object',


### PR DESCRIPTION
Currently, S3 attachments with a comma in the filename can't be launched.

To create the filename, frappe_s3_attachment strips out all special characters. This is fine 👍 

But it also creates a variable called file_name which is the unedited original filename. This gets used as the response-content-disposition. All this header is supposed to be for is to provide information about how to display the file, so it's being misused here. It's completely unnecessary for getting the file from S3 - if you just call generate_file without the file_name, it works fine and loads the attachment.

So this PR just stops using file_name in generate_file, which means all our currently broken attachments will start working without any backfilling needed.